### PR TITLE
Issue/82  - External Command Prefixes (and overrides)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "symfony/finder": "^5.1",
         "symfony/dependency-injection": "^5.2",
         "symfony/config": "^5.2",
-        "consolidation/self-update": "^1.2"
+        "consolidation/self-update": "^1.2",
+        "symfony/deprecation-contracts": "^2.4"
     },
     "bin": [
         "bin/waffle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0632e371f2cbe8d12c346175b76a2cb5",
+    "content-hash": "e594acf57665f6662b44670be5ede258",
     "packages": [
         {
             "name": "consolidation/self-update",
@@ -317,16 +317,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.2.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665"
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5fa56b4074d1ae755beb55617ddafe6f5d78f665",
-                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
                 "shasum": ""
             },
             "require": {
@@ -335,7 +335,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "2.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -363,7 +363,7 @@
             ],
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2021-03-23T23:28:01+00:00"
         },
         {
             "name": "symfony/filesystem",

--- a/src/Application.php
+++ b/src/Application.php
@@ -57,6 +57,9 @@ class Application extends SymfonyApplication
 
         // Prevent auto exiting (so we can run extra code).
         $this->setAutoExit(false);
+
+        // Adding some mechanism to watch out for deprecated code.
+        $this->initalizeDeprecationCatcher();
     }
 
     /**
@@ -229,5 +232,32 @@ class Application extends SymfonyApplication
         }
 
         return $latest;
+    }
+
+    /**
+     * Sets an error handler that listens for user deprecated code.
+     */
+    private function initalizeDeprecationCatcher()
+    {
+        // TODO -- This is a start, but this will only work once Waffle has
+        // bootstrapped for the most part. We may need to do something similar
+        // earlier in the application lifecycle before this can take over.
+        $that = $this;
+
+        set_error_handler(function (...$args) use ($that) {
+            $that->handleDeprecation(...$args);
+        }, \E_USER_DEPRECATED);
+    }
+
+    /**
+     * Helper method to emit warnings to users when deprecated code is called.
+     */
+    private function handleDeprecation($err_no, $err_msg, $filename, $linenum)
+    {
+        // TODO - These may be easy to lose in the output. Perhaps we should
+        // store a list of these and print them out before we exit.
+
+        // Not much we need to do here. Just emitting a warning for now.
+        $this->io->warning($err_msg);
     }
 }

--- a/src/Model/Cli/Command/ComposerCommand.php
+++ b/src/Model/Cli/Command/ComposerCommand.php
@@ -3,6 +3,7 @@
 namespace Waffle\Model\Cli\Command;
 
 use Waffle\Model\Cli\BaseCliCommand;
+use Waffle\Model\Config\Item\Bin;
 use Waffle\Model\Context\Context;
 
 class ComposerCommand extends BaseCliCommand
@@ -13,7 +14,8 @@ class ComposerCommand extends BaseCliCommand
      */
     public function __construct(Context $context, array $args)
     {
-        array_unshift($args, 'composer');
+        $binary = $context->getBin(Bin::BIN_COMPOSER);
+        array_unshift($args, $binary);
         parent::__construct($context, $args);
     }
 }

--- a/src/Model/Cli/Command/DrushCommand.php
+++ b/src/Model/Cli/Command/DrushCommand.php
@@ -3,6 +3,7 @@
 namespace Waffle\Model\Cli\Command;
 
 use Waffle\Model\Cli\BaseCliCommand;
+use Waffle\Model\Config\Item\Bin;
 use Waffle\Model\Context\Context;
 
 class DrushCommand extends BaseCliCommand
@@ -13,7 +14,8 @@ class DrushCommand extends BaseCliCommand
      */
     public function __construct(Context $context, array $args)
     {
-        array_unshift($args, 'drush');
+        $binary = $context->getBin(Bin::BIN_DRUSH);
+        array_unshift($args, $binary);
         parent::__construct($context, $args);
     }
 }

--- a/src/Model/Cli/Command/GitCommand.php
+++ b/src/Model/Cli/Command/GitCommand.php
@@ -3,6 +3,7 @@
 namespace Waffle\Model\Cli\Command;
 
 use Waffle\Model\Cli\BaseCliCommand;
+use Waffle\Model\Config\Item\Bin;
 use Waffle\Model\Context\Context;
 
 class GitCommand extends BaseCliCommand
@@ -13,7 +14,8 @@ class GitCommand extends BaseCliCommand
      */
     public function __construct(Context $context, array $args)
     {
-        array_unshift($args, 'git');
+        $binary = $context->getBin(Bin::BIN_GIT);
+        array_unshift($args, $binary);
         parent::__construct($context, $args);
     }
 }

--- a/src/Model/Cli/Command/GulpCommand.php
+++ b/src/Model/Cli/Command/GulpCommand.php
@@ -3,6 +3,7 @@
 namespace Waffle\Model\Cli\Command;
 
 use Waffle\Model\Cli\BaseCliCommand;
+use Waffle\Model\Config\Item\Bin;
 use Waffle\Model\Context\Context;
 
 class GulpCommand extends BaseCliCommand
@@ -13,7 +14,8 @@ class GulpCommand extends BaseCliCommand
      */
     public function __construct(Context $context, array $args)
     {
-        array_unshift($args, 'gulp');
+        $binary = $context->getBin(Bin::BIN_GULP);
+        array_unshift($args, $binary);
         parent::__construct($context, $args);
     }
 }

--- a/src/Model/Cli/Command/NpmCommand.php
+++ b/src/Model/Cli/Command/NpmCommand.php
@@ -3,6 +3,7 @@
 namespace Waffle\Model\Cli\Command;
 
 use Waffle\Model\Cli\BaseCliCommand;
+use Waffle\Model\Config\Item\Bin;
 use Waffle\Model\Context\Context;
 
 class NpmCommand extends BaseCliCommand
@@ -13,7 +14,8 @@ class NpmCommand extends BaseCliCommand
      */
     public function __construct(Context $context, array $args)
     {
-        array_unshift($args, 'npm');
+        $binary = $context->getBin(Bin::BIN_NPM);
+        array_unshift($args, $binary);
         parent::__construct($context, $args);
     }
 }

--- a/src/Model/Cli/Command/SymfonyCliCommand.php
+++ b/src/Model/Cli/Command/SymfonyCliCommand.php
@@ -3,6 +3,7 @@
 namespace Waffle\Model\Cli\Command;
 
 use Waffle\Model\Cli\BaseCliCommand;
+use Waffle\Model\Config\Item\Bin;
 use Waffle\Model\Context\Context;
 
 class SymfonyCliCommand extends BaseCliCommand
@@ -13,7 +14,8 @@ class SymfonyCliCommand extends BaseCliCommand
      */
     public function __construct(Context $context, array $args)
     {
-        array_unshift($args, 'symfony');
+        $binary = $context->getBin(Bin::BIN_SYMFONY);
+        array_unshift($args, $binary);
         parent::__construct($context, $args);
     }
 }

--- a/src/Model/Cli/Command/WpCliCommand.php
+++ b/src/Model/Cli/Command/WpCliCommand.php
@@ -3,6 +3,7 @@
 namespace Waffle\Model\Cli\Command;
 
 use Waffle\Model\Cli\BaseCliCommand;
+use Waffle\Model\Config\Item\Bin;
 use Waffle\Model\Context\Context;
 
 class WpCliCommand extends BaseCliCommand
@@ -13,7 +14,8 @@ class WpCliCommand extends BaseCliCommand
      */
     public function __construct(Context $context, array $args)
     {
-        array_unshift($args, 'wp');
+        $binary = $context->getBin(Bin::BIN_WP_CLI);
+        array_unshift($args, $binary);
         parent::__construct($context, $args);
     }
 }

--- a/src/Model/Config/Item/Bin.php
+++ b/src/Model/Config/Item/Bin.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Waffle\Model\Config\Item;
+
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Waffle\Model\Config\BaseConfigItem;
+use Waffle\Model\Config\ConfigItemInterface;
+
+class Bin extends BaseConfigItem
+{
+    /**
+     * @var string
+     *
+     * The key for this config item.
+     */
+    public const KEY = 'bin';
+
+    /**
+     * @var string
+     *
+     * Config key for the composer binary.
+     */
+    public const BIN_COMPOSER = 'composer';
+
+    /**
+     * @var string
+     *
+     * Config key for the drush binary.
+     */
+    public const BIN_DRUSH = 'drush';
+
+    /**
+     * @var string
+     *
+     * Config key for the gulp binary.
+     */
+    public const BIN_GULP = 'gulp';
+
+    /**
+     * @var string
+     *
+     * Config key for the npm binary.
+     */
+    public const BIN_NPM = 'npm';
+
+    /**
+     * @var string
+     *
+     * Config key for the symfony binary.
+     */
+    public const BIN_SYMFONY = 'symfony';
+
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        parent::__construct(
+            self::KEY,
+            [
+                ConfigItemInterface::SCOPE_GLOBAL,
+                ConfigItemInterface::SCOPE_PROJECT,
+                ConfigItemInterface::SCOPE_LOCAL,
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition()
+    {
+        $nodeBuilder = new NodeBuilder();
+        return $nodeBuilder->arrayNode(self::KEY)
+            ->children()
+                ->scalarNode(self::BIN_COMPOSER)->end()
+                ->scalarNode(self::BIN_DRUSH)->end()
+                ->scalarNode(self::BIN_GULP)->end()
+                ->scalarNode(self::BIN_NPM)->end()
+                ->scalarNode(self::BIN_SYMFONY)->end()
+            ->end();
+    }
+}

--- a/src/Model/Config/Item/Bin.php
+++ b/src/Model/Config/Item/Bin.php
@@ -32,6 +32,13 @@ class Bin extends BaseConfigItem
     /**
      * @var string
      *
+     * Config key for the git binary.
+     */
+    public const BIN_GIT = 'git';
+
+    /**
+     * @var string
+     *
      * Config key for the gulp binary.
      */
     public const BIN_GULP = 'gulp';
@@ -50,6 +57,12 @@ class Bin extends BaseConfigItem
      */
     public const BIN_SYMFONY = 'symfony';
 
+    /**
+     * @var string
+     *
+     * Config key for the wp-cli binary.
+     */
+    public const BIN_WP_CLI = 'wp';
 
     /**
      * Constructor
@@ -76,9 +89,11 @@ class Bin extends BaseConfigItem
             ->children()
                 ->scalarNode(self::BIN_COMPOSER)->end()
                 ->scalarNode(self::BIN_DRUSH)->end()
+                ->scalarNode(self::BIN_GIT)->end()
                 ->scalarNode(self::BIN_GULP)->end()
                 ->scalarNode(self::BIN_NPM)->end()
                 ->scalarNode(self::BIN_SYMFONY)->end()
+                ->scalarNode(self::BIN_WP_CLI)->end()
             ->end();
     }
 }

--- a/src/Model/Context/Context.php
+++ b/src/Model/Context/Context.php
@@ -269,14 +269,22 @@ class Context implements ConfigurationInterface
      */
     public function getCommandPrefix()
     {
-        /**
-         * @todo The code below is part of the previous implementation of this,
-         * that needs to be re-implemented.
-         *
-         * See src/Model/Config/Item/CommandPrefix.php
-         */
+        // See src/Model/Config/Item/CommandPrefix.php
+        $prefix = $this->get(CommandPrefix::KEY);
 
-        return $this->get(CommandPrefix::KEY);
+        if (!is_null($prefix)) {
+            trigger_deprecation(
+                'waffle-ops/waffle',
+                'v0.1.0',
+                sprintf(
+                    'The "%s" configuration item is deprecated and will be removed'
+                    . ' before v1.0.0. Use the "bin" configuration item instead.',
+                    CommandPrefix::KEY
+                )
+            );
+        }
+
+        return $prefix;
     }
 
     /**
@@ -380,7 +388,8 @@ class Context implements ConfigurationInterface
      *
      * @return string
      */
-    public function getBin($bin){
+    public function getBin($bin)
+    {
         return $this->config[Bin::KEY][$bin] ?? $bin;
     }
 }

--- a/src/Model/Context/Context.php
+++ b/src/Model/Context/Context.php
@@ -7,6 +7,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Waffle\Model\Cli\Runner\Composer;
 use Waffle\Model\Config\ConfigTreeService;
 use Waffle\Model\Config\Item\Alias;
+use Waffle\Model\Config\Item\Bin;
 use Waffle\Model\Config\Item\Cms;
 use Waffle\Model\Config\Item\CommandPrefix;
 use Waffle\Model\Config\Item\ComposerPath;
@@ -370,5 +371,16 @@ class Context implements ConfigurationInterface
     public function getEnvironmentVariables()
     {
         return $this->get(EnvironmentVariables::KEY);
+    }
+
+    /**
+     * Gets the configured binary for use with external tools.
+     *
+     * Returns $bin in the event that no override is found.
+     *
+     * @return string
+     */
+    public function getBin($bin){
+        return $this->config[Bin::KEY][$bin] ?? $bin;
     }
 }


### PR DESCRIPTION
New prefix / override system for external tools! This should be particularly useful for projects using Lando.

### Example 1 -- Lando prefix
```yml
# In .waffle.yml
bin:
  composer: 'lando composer'
  drush: 'lando drush'
  gulp: 'lando gulp'
  npm: 'lando npm'
```
In this example, composer, drush, gulp, and npm commands issues by Waffle will be prefixed with `lando`. Tools not listed here such as `git` will continue to use the default value (or what is in the global / local scope).

### Example 2 -- Target specific version of tools.
```yml
# In .waffle.yml
bin:
  composer: 'composer1'
```
In this example, I'm assuming that `composer1` is installed and on your `$PATH` such that you have upgraded to Composer 2 but this particular project needs Composer 1 still (ie, on Magento, or another framework that tends to lag behind somewhat). Tools not listed here such as `git` will continue to use the default value (or what is in the global / local scope).