### PR TITLE
#103 - Add initial compass support for `build-frontend`.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -85,3 +85,6 @@ services:
 
   Waffle\Model\Build\Frontend\GulpFrontendBuildHandler:
     public: true
+
+  Waffle\Model\Build\Frontend\CompassFrontendBuildHandler:
+    public: true

--- a/src/Command/Task/BuildFrontend.php
+++ b/src/Command/Task/BuildFrontend.php
@@ -50,7 +50,7 @@ class BuildFrontend extends BaseTask implements DiscoverableTaskInterface
             BuildFrontendConfig::STRATEGY_KEY,
             null,
             InputArgument::OPTIONAL,
-            'The strategy used for building the frontend (none, gulp, ect...)',
+            'The strategy used for building the frontend (none, gulp, compass, etc...)',
             null
         );
     }

--- a/src/Model/Build/Frontend/CompassFrontendBuildHandler.php
+++ b/src/Model/Build/Frontend/CompassFrontendBuildHandler.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Waffle\Model\Build\Frontend;
+
+use Waffle\Helper\CliHelper;
+use Waffle\Model\Build\BuildHandlerInterface;
+use Waffle\Model\Cli\Runner\Compass;
+use Waffle\Model\Cli\Runner\Npm;
+
+class CompassFrontendBuildHandler implements BuildHandlerInterface
+{
+    /**
+     * @var CliHelper
+     */
+    private $cliHelper;
+
+    /**
+     * @var Npm
+     */
+    private $npm;
+
+    /**
+     * @var Compass
+     */
+    private $compass;
+
+    /**
+     * Constructor
+     *
+     * @param CliHelper $cliHelper
+     * @param Npm $npm
+     * @param Compass $compass
+     */
+    public function __construct(
+        CliHelper $cliHelper,
+        Npm $npm,
+        Compass $compass
+    ) {
+        $this->cliHelper = $cliHelper;
+        $this->npm = $npm;
+        $this->compass = $compass;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle()
+    {
+        // @todo: install dependencies (gem install, etc)
+
+        $process = $this->compass->compile();
+        $this->cliHelper->outputOrFail($process, 'Running compass compile.');
+    }
+}

--- a/src/Model/Build/FrontendBuildHandlerFactory.php
+++ b/src/Model/Build/FrontendBuildHandlerFactory.php
@@ -4,6 +4,7 @@ namespace Waffle\Model\Build;
 
 use Waffle\Helper\DiHelper;
 use Waffle\Model\Build\Frontend\GulpFrontendBuildHandler;
+use Waffle\Model\Build\Frontend\CompassFrontendBuildHandler;
 use Waffle\Model\Config\Item\BuildFrontend;
 
 class FrontendBuildHandlerFactory
@@ -40,11 +41,16 @@ class FrontendBuildHandlerFactory
             case BuildFrontend::STRATEGY_GULP:
                 return $this->diHelper->getContainer()->get(GulpFrontendBuildHandler::class);
 
+            case BuildFrontend::STRATEGY_COMPASS:
+                return $this->diHelper->getContainer()->get(CompassFrontendBuildHandler::class);
+
             default:
-                throw new \Exception(sprintf(
-                    'Frontend build strategy \'%s\' not implemented.',
-                    $strategy
-                ));
+                throw new \Exception(
+                    sprintf(
+                        'Frontend build strategy \'%s\' not implemented.',
+                        $strategy
+                    )
+                );
         }
     }
 }

--- a/src/Model/Cli/Command/CompassCommand.php
+++ b/src/Model/Cli/Command/CompassCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Waffle\Model\Cli\Command;
+
+use Waffle\Model\Cli\BaseCliCommand;
+use Waffle\Model\Config\Item\Bin;
+use Waffle\Model\Context\Context;
+
+class CompassCommand extends BaseCliCommand
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(Context $context, array $args)
+    {
+        $binary = $context->getBin(Bin::BIN_COMPASS);
+        array_unshift($args, $binary);
+        parent::__construct($context, $args);
+    }
+}

--- a/src/Model/Cli/Factory/CompassCommandFactory.php
+++ b/src/Model/Cli/Factory/CompassCommandFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Waffle\Model\Cli\Factory;
+
+use Waffle\Model\Cli\BaseCliCommandFactory;
+use Waffle\Model\Cli\Command\CompassCommand;
+use Waffle\Model\Context\Context;
+use Exception;
+
+class CompassCommandFactory extends BaseCliCommandFactory
+{
+
+    /**
+     * @var Context
+     */
+    protected $context;
+
+    /**
+     * Constructor
+     *
+     * @param Context $context
+     */
+    public function __construct(Context $context)
+    {
+        parent::__construct($context);
+    }
+
+    /**
+     * Creates a new ComposerCommand instance.
+     *
+     * @param string[] $args
+     *
+     * @return CompassCommand
+     * @throws Exception
+     */
+    public function create(array $args): CompassCommand
+    {
+        return new CompassCommand($this->context, $args);
+    }
+}

--- a/src/Model/Cli/Runner/Compass.php
+++ b/src/Model/Cli/Runner/Compass.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Waffle\Model\Cli\Runner;
+
+use Symfony\Component\Process\Process;
+use Waffle\Model\Cli\BaseCliRunner;
+use Waffle\Model\Cli\Factory\CompassCommandFactory;
+use Waffle\Model\Context\Context;
+use Waffle\Model\IO\IOStyle;
+
+class Compass extends BaseCliRunner
+{
+
+    /**
+     * @var CompassCommandFactory
+     */
+    private $compassCommandFactory;
+
+    /**
+     * Constructor
+     *
+     * @param Context $context
+     * @param IOStyle $io
+     * @param CompassCommandFactory $compassCommandFactory
+     *
+     */
+    public function __construct(
+        Context $context,
+        IOStyle $io,
+        CompassCommandFactory $compassCommandFactory
+    ) {
+        $this->compassCommandFactory = $compassCommandFactory;
+        parent::__construct($context, $io);
+    }
+
+    /**
+     * Runs 'compass compile --force'.
+     *
+     * Assumption is that the 'build' task exists in the compass config file.
+     *
+     * @return Process
+     */
+    public function compile(): Process
+    {
+        $command = $this->compassCommandFactory->create(['compile', '--force']);
+        return $command->getProcess();
+    }
+}

--- a/src/Model/Config/Item/Bin.php
+++ b/src/Model/Config/Item/Bin.php
@@ -46,6 +46,13 @@ class Bin extends BaseConfigItem
     /**
      * @var string
      *
+     * Config key for the compass binary.
+     */
+    public const BIN_COMPASS = 'compass';
+
+    /**
+     * @var string
+     *
      * Config key for the npm binary.
      */
     public const BIN_NPM = 'npm';

--- a/src/Model/Config/Item/BuildFrontend.php
+++ b/src/Model/Config/Item/BuildFrontend.php
@@ -39,6 +39,13 @@ class BuildFrontend extends BaseConfigItem
     /**
      * @var string
      *
+     * Expected value in cases where compass frontend strategy is needed.
+     */
+    public const STRATEGY_COMPASS = 'compass';
+
+    /**
+     * @var string
+     *
      * Key for directory option.
      */
     public const DIRECTORY_KEY = 'dir';
@@ -46,11 +53,12 @@ class BuildFrontend extends BaseConfigItem
     /**
      * @var array
      *
-     * An array containing a list of avaliable strategy options.
+     * An array containing a list of available strategy options.
      */
     public const STRATEGY_OPTIONS = [
         self::STRATEGY_NONE,
         self::STRATEGY_GULP,
+        self::STRATEGY_COMPASS
     ];
 
     /**


### PR DESCRIPTION
Works, but requires user to run `gem install` manually before running `build-frontend`.